### PR TITLE
Create workflow for mirroring from github to launchpad

### DIFF
--- a/.github/workflows
+++ b/.github/workflows
@@ -1,0 +1,25 @@
+name: Mirroring to Launchpad
+
+# Launchpad project:
+# https://code.launchpad.net/checkbox-provider-edgex
+
+on: 
+  push:
+    branches:
+      - master
+
+jobs:
+  launchpad_mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url:
+            https://git.launchpad.net/checkbox-provider-edgex
+          ssh_private_key:
+            ${{ secrets.LP_PRIVATE_KEY }}
+          ssh_username:                          
+            ${{ secrets.LP_USERNAME }}


### PR DESCRIPTION
Since the source code had moved to Github, this workflow is added to mirror the state of master to Launchpad.

Github: https://github.com/canonical/edgex-checkbox-provide
Launchpad: https://code.launchpad.net/checkbox-provider-edgex