### PR TITLE
Replace orchestration delays with context-aware timers

### DIFF
--- a/data/jakarta/test-config-hook.sh
+++ b/data/jakarta/test-config-hook.sh
@@ -74,9 +74,7 @@ else
 fi
 
 # wait for services to come online
-# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-# to accomodate time for everything to come online
-sleep 120
+snap_wait_all_services_online
 
 test_smtp() {
     # [Smtp] support-notifications options

--- a/data/jakarta/test-device-virtual.sh
+++ b/data/jakarta/test-device-virtual.sh
@@ -20,15 +20,13 @@ else
 fi
 
 # wait for services to come online
-# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-# to accomodate time for everything to come online
-sleep 120
+snap_wait_all_services_online
 
 # start device-virtual
 snap start edgexfoundry.device-virtual
 
-# wait 120 seconds as device-virtual takes close to ~2:30 before devices are created
-sleep 120
+# wait for service to come online
+snap_wait_port_status 59900 open
 
 # ensure device-virtual is running
 if [ "$(snap services edgexfoundry.device-virtual | grep -o inactive)" = "inactive" ]; then

--- a/data/jakarta/test-install-config-paths.sh
+++ b/data/jakarta/test-install-config-paths.sh
@@ -23,9 +23,7 @@ fi
 SNAP_REVISION=$(snap run --shell edgexfoundry.consul -c "echo \$SNAP_REVISION")
 
 # wait for services to come online
-# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-# to accomodate time for everything to come online
-sleep 120
+snap_wait_all_services_online
 
 echo "checking for files with snap revision $SNAP_REVISION"
 

--- a/data/jakarta/test-network-interfaces.sh
+++ b/data/jakarta/test-network-interfaces.sh
@@ -20,9 +20,7 @@ else
 fi
 
 # wait for services to come online
-# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-# to accomodate time for everything to come online
-sleep 120
+snap_wait_all_services_online
 
 # edgex's core-data service listens by default on port 59880. Ensure that
 # it's not listening on all interfaces (e.g. *:59880), and can only be

--- a/data/jakarta/test-refresh-config-paths.sh
+++ b/data/jakarta/test-refresh-config-paths.sh
@@ -42,9 +42,7 @@ for channel in edge; do
     SNAP_REVISION=$(snap run --shell edgexfoundry.consul -c "echo \$SNAP_REVISION")
     
     # wait for services to come online
-    # NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-    # to accomodate time for everything to come online
-    sleep 120
+    snap_wait_all_services_online
 
     # now install the snap version we are testing and check again
     if [ -n "$REVISION_TO_TEST" ]; then
@@ -56,7 +54,7 @@ for channel in edge; do
     # wait for services to come online
     # NOTE: this may have to be significantly increased on arm64 or low RAM platforms
     # to accomodate time for everything to come online
-    sleep 240
+    snap_wait_all_services_online
 
     echo "checking for files with previous snap revision $SNAP_REVISION"
 

--- a/data/jakarta/test-refresh-services.sh
+++ b/data/jakarta/test-refresh-services.sh
@@ -38,9 +38,8 @@ for channel in edge; do
             ;;
     esac
     # wait for services to come online
-    # NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-    # to accomodate time for everything to come online
-    sleep 120
+    snap_wait_all_services_online
+    
     snap_check_jakarta_svcs
 
     # now install the snap version we are testing and check again
@@ -50,9 +49,7 @@ for channel in edge; do
         snap_refresh edgexfoundry "$DEFAULT_TEST_CHANNEL"  
     fi
     # wait for services to come online
-    # NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-    # to accomodate time for everything to come online
-    sleep 120
+    snap_wait_all_services_online
 
     snap_check_jakarta_svcs --notfatal
 

--- a/data/jakarta/test-rules-engine.sh
+++ b/data/jakarta/test-rules-engine.sh
@@ -29,13 +29,12 @@ else
 fi
 
 # wait for services to come online
-# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-# to accomodate time for everything to come online
-sleep 120
+snap_wait_all_services_online
 
 # enable kuiper/rules engine, as it's disabled by default
 snap set edgexfoundry kuiper=on
-sleep 15
+snap_wait_port_status 59720 open
+
 
 # make sure that kuiper/rules engine is started
 if [ -n "$(snap services edgexfoundry.kuiper | grep edgexfoundry.kuiper | grep inactive)" ] ; then
@@ -139,7 +138,7 @@ fi
 
 # disable the kuiper for app-service-configurable
 snap set edgexfoundry kuiper=off
-sleep 15
+snap_wait_port_status 59720 close
 
 # check that kuiper/rules engine is no longer running 
 if [ -z "$(snap services edgexfoundry.kuiper | grep edgexfoundry.kuiper | grep inactive)" ]; then

--- a/data/jakarta/test-self-refresh-services.sh
+++ b/data/jakarta/test-self-refresh-services.sh
@@ -21,9 +21,7 @@ else
 fi
 
 # wait for services to come online
-# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-# to accomodate time for everything to come online
-sleep 120
+snap_wait_all_services_online
 
 # now install the same snap version we are testing to test the pre-refresh
 # and post-refresh logic in this revision
@@ -38,9 +36,7 @@ else
 fi
 
 # wait for services to come online
-# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-# to accomodate time for everything to come online
-sleep 120
+snap_wait_all_services_online
 
 snap_check_jakarta_svcs
 

--- a/data/jakarta/test-services-alive.sh
+++ b/data/jakarta/test-services-alive.sh
@@ -20,9 +20,7 @@ else
 fi
 
 # wait for services to come online
-# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-# to accomodate time for everything to come online
-sleep 120
+snap_wait_all_services_online
 
 # check services
 snap_check_jakarta_svcs

--- a/data/jakarta/test-sys-mgmt-agent.sh
+++ b/data/jakarta/test-sys-mgmt-agent.sh
@@ -20,13 +20,11 @@ else
 fi
 
 # wait for services to come online
-# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
-# to accomodate time for everything to come online
-sleep 120
+snap_wait_all_services_online
 
 # enable sys-mgmt-agent, as it's disabled by default
 snap set edgexfoundry sys-mgmt-agent=on
-sleep 15
+snap_wait_port_status 58890 open
 
 # make sure that core-data is running
 if [ -n "$(snap services edgexfoundry.core-data | grep edgexfoundry.core-data | grep inactive)" ]; then

--- a/data/jakarta/utils.sh
+++ b/data/jakarta/utils.sh
@@ -131,12 +131,13 @@ snap_remove()
 # to accomodate time for everything to come online
 snap_wait_all_services_online()
 {
-    regex="4[0-9][0-9]|5[0-9][0-9]"
+    http_error_code_regex="4[0-9][0-9]|5[0-9][0-9]"
     all_services_online=false
     i=0
 
     while [ "$all_services_online" = "false" ];
     do
+        echo "waiting for all services to come online. Current retry count: $i/300"
         #max retry avoids forever waiting
         ((i=i+1))
         if [ "$i" -ge 300 ]; then
@@ -146,25 +147,22 @@ snap_wait_all_services_online()
 
         #dial services
         core_data_status_code=$(curl --insecure --silent --include \
-            --connect-timeout 2 --max-time 300 \
+            --connect-timeout 2 --max-time 5 \
             --output /dev/null --write-out "%{http_code}" \
-            -X GET 'http://localhost:59880/api/v2/ping' \
-            -H 'accept: application/json') || true
+            -X GET 'http://localhost:59880/api/v2/ping') || true
         core_metadata_status_code=$(curl --insecure --silent --include \
-            --connect-timeout 2 --max-time 300 \
+            --connect-timeout 2 --max-time 5 \
             --output /dev/null --write-out "%{http_code}" \
-            -X GET 'http://localhost:59881/api/v2/ping' \
-            -H 'accept: application/json') || true
+            -X GET 'http://localhost:59881/api/v2/ping') || true
         core_command_status_code=$(curl --insecure --silent --include \
-            --connect-timeout 2 --max-time 300 \
+            --connect-timeout 2 --max-time 5 \
             --output /dev/null --write-out "%{http_code}" \
-            -X GET 'http://localhost:59882/api/v2/ping' \
-            -H 'accept: application/json') || true
+            -X GET 'http://localhost:59882/api/v2/ping') || true
 
         #error status 4xx/5xx will fail the test immediately
-        if [[ $core_data_status_code =~ $regex ]] \
-            || [[ $core_metadata_status_code =~ $regex ]] \
-            || [[ $core_command_status_code =~ $regex ]]; then
+        if [[ $core_data_status_code =~ $http_error_code_regex ]] \
+            || [[ $core_metadata_status_code =~ $http_error_code_regex ]] \
+            || [[ $core_command_status_code =~ $http_error_code_regex ]]; then
             echo "core service(s) received status code 4xx or 5xx"
             exit 1
         fi


### PR DESCRIPTION
- dial relevant ports via `snap_wait_port_status()`
- check http status codes via `snap_wait_all_services_online()`
- enable one recheck test, and replace sleep time inside it
### Test
```
git clone https://github.com/MonicaisHer/edgex-checkbox-provider.git
cd edgex-checkbox-provider/data/jakarta/
git checkout replace-orchestration-delays-with-context-aware-timers 
time (sudo ./run-all-tests-locally.sh)
```
It takes about 49m, which decreased from 77m via implementing this PR.

Or you can test one single test. Here is an example:
```
time (sudo ./run-all-tests-locally.sh -t test-security-services-proxy-certs.sh)
```