### PR TITLE
Add instructions for testing snap from a channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For example, to run a single test with a local snap:
 sudo ./run-all-tests-locally.sh -s edgexfoundry.snap -t test-rules-engine.sh
 ```
 
-To run tests on a snap from a specific channel:
+To run tests against a snap from a specific channel:
 ```bash
 DEFAULT_TEST_CHANNEL="<channel>" sudo ./run-all-tests-locally.sh
 ```

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ For example, to run a single test with a local snap:
 sudo ./run-all-tests-locally.sh -s edgexfoundry.snap -t test-rules-engine.sh
 ```
 
+To run tests on a snap from a specific channel:
+```bash
+DEFAULT_TEST_CHANNEL="<channel>" sudo ./run-all-tests-locally.sh
+```
+
 ## Testing coverage
 - Test the installation of edgexfoundry snap
 - Test security services proxy certs work properly


### PR DESCRIPTION
This can be used to tests snaps locally from other tracks, risk levels, or branches.