### PR TITLE
add test for refreshing to core 20 via bridge snap

### DIFF
--- a/data/latest/test-refresh-core-18-20.sh
+++ b/data/latest/test-refresh-core-18-20.sh
@@ -1,0 +1,105 @@
+#!/bin/bash -e
+
+# This test validates that Kong configuration is correctly migrated from
+# postgres 10 to postgres 12.
+
+# get the directory of this script
+# snippet from https://stackoverflow.com/a/246128/10102404
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# load the latest release utils
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/utils.sh"
+
+START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
+
+DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
+
+# remove the current snap
+snap_remove
+
+# install 2.0/stable
+snap_install edgexfoundry "2.0/stable"
+
+# wait for services to come online
+snap_wait_all_services_online
+
+# generate a user and the JWT token
+
+# Due to confinement issues when running this test, we write the private key to SNAP_DATA
+EDGEXFOUNDRY_SNAP_DATA="/var/snap/edgexfoundry/current/checkbox"
+mkdir -p $EDGEXFOUNDRY_SNAP_DATA
+
+echo "Generating private key"
+openssl ecparam -genkey -name prime256v1 -noout -out $EDGEXFOUNDRY_SNAP_DATA/private.pem
+echo "Generating public key"
+openssl ec -in $EDGEXFOUNDRY_SNAP_DATA/private.pem -pubout -out $EDGEXFOUNDRY_SNAP_DATA/public.pem
+PUBLIC_KEY=$(< $EDGEXFOUNDRY_SNAP_DATA/public.pem)
+ 
+echo "Setting security-proxy user"
+snap set edgexfoundry env.security-proxy.user=user01,USER_ID,ES256
+echo "Setting security-proxy public key"
+snap set edgexfoundry env.security-proxy.public-key="$PUBLIC_KEY"
+
+echo "Generating JWT"
+# this command doesn't write errors to stderr. Check the exit code before using the output:
+if ! OUT=$(edgexfoundry.secrets-config proxy jwt --algorithm ES256 --private_key $EDGEXFOUNDRY_SNAP_DATA/private.pem --id USER_ID --expiration=1h)
+then
+    print_error_logs
+    >&2 echo $OUT
+    exit 1
+fi
+TOKEN=$OUT
+
+echo "Got Token: $TOKEN"
+
+# note: we need to use "edgexfoundry.curl", not "curl" to correctly support TLS 1.2
+echo "Verifying JWT token using edgexfoundry 2.0/stable"
+code=$(edgexfoundry.curl --insecure --show-error --silent --include \
+    --output /dev/null --write-out "%{http_code}" \
+    -X GET 'https://localhost:8443/core-data/api/v2/ping?' \
+    -H "Authorization: Bearer $TOKEN") 
+if [[ $code != 200 ]]; then
+    print_error_logs
+    >&2 echo "JWT authentication failed with $code"
+    snap_remove
+    exit 1
+else
+    echo "JWT authentication succeeded"
+fi
+
+# now install the snap version we are testing and check again
+
+if [ -n "$REVISION_TO_TEST" ]; then
+    echo "Installing $REVISION_TO_TEST"
+    snap_install "$REVISION_TO_TEST" "$REVISION_TO_TEST_CHANNEL" "$REVISION_TO_TEST_CONFINEMENT"
+else
+    echo "Installing edgexfoundry --channel=$DEFAULT_TEST_CHANNEL"
+    snap_refresh edgexfoundry "$DEFAULT_TEST_CHANNEL"
+fi
+
+# wait for services to come online
+# NOTE: this may have to be significantly increased on arm64 or low RAM platforms
+# to accomodate time for everything to come online
+snap_wait_all_services_online
+ 
+
+# recheck
+code=$(edgexfoundry.curl --insecure --show-error --silent --include \
+    --output /dev/null --write-out "%{http_code}" \
+    -X GET 'https://localhost:8443/core-data/api/v2/ping?' \
+    -H "Authorization: Bearer $TOKEN")
+if [[ $code != 200 ]]; then
+    print_error_logs
+    >&2 echo "JWT authentication failed with $code"
+    snap_remove
+    exit 1
+else
+    echo "JWT authentication succeeded"
+fi
+ 
+echo "All done. Cleaning up"
+# remove the snap to run the next test
+snap_remove
+ 
+

--- a/units/latest.pxu
+++ b/units/latest.pxu
@@ -78,3 +78,10 @@ environ: DEFAULT_TEST_CHANNEL REVISION_TO_TEST REVISION_TO_TEST_CHANNEL REVISION
 category_id: edgex
 flags: simple
 
+id: edgex/latest/refresh-core-18-20
+_summary: Test that the Kong configuration is migrated correctly when upgrading from core 18 to 20
+command: $PLAINBOX_PROVIDER_DATA/latest/test-refresh-core-18-20.sh
+user: root
+environ: DEFAULT_TEST_CHANNEL REVISION_TO_TEST REVISION_TO_TEST_CHANNEL REVISION_TO_TEST_CONFINEMENT
+category_id: edgex
+flags: simple


### PR DESCRIPTION

This test does the following:
1. install version 2.0/latest of edgexfoundry
2. Create a JWT token and verify it
3. refresh to the snap version being tested. 
4. If this is set to "latest/edge" then the expected behaviour is to install the epoch 6* snap, followed by the epoch 6 snap
5. verify the JWT token again

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

Once this test is merged, we will push the Epoch 6* and 6 snaps to latest/beta.

You can run this test (and all other checkbox tests in the test suite) by doing the following:

1. get the `checkbox-edgexfoundry` snap
```
snap download checkbox-edgexfoundry --edge
unsquashfs checkbox-edgexfoundry_117.snap
```

2. copy the two updated files from this commit

```
cp .../edgex-checkbox-provider/units/latest.pxu ./squashfs-root/providers/checkbox-provider-edgex/units/
cp .../edgex-checkbox-provider/data/latest/test-refresh-core-18-20.sh ./squashfs-root/providers/checkbox-provider-edgex/data/latest/
```

3. run the tests with:

```
mksquashfs ./squashfs-root checkbox-edgexfoundry.snap  -noappend -comp xz -all-root -no-xattrs -no-fragments
sudo snap install ./checkbox-edgexfoundry.snap --devmode
snap connect checkbox-edgexfoundry:checkbox-runtime checkbox16:checkbox-runtime
sudo DEFAULT_TEST_CHANNEL="latest/edge" checkbox-edgexfoundry.latest
```

