### PR TITLE
Fix default channel and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sudo ./run-all-tests-locally.sh -s edgexfoundry.snap -t test-rules-engine.sh
 
 To run tests against a snap from a specific channel:
 ```bash
-DEFAULT_TEST_CHANNEL="<channel>" sudo ./run-all-tests-locally.sh
+sudo DEFAULT_TEST_CHANNEL="<channel>" ./run-all-tests-locally.sh
 ```
 
 ## Testing coverage

--- a/data/latest/run-all-tests-locally.sh
+++ b/data/latest/run-all-tests-locally.sh
@@ -4,20 +4,11 @@
 # snippet from https://stackoverflow.com/a/246128/10102404
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-if [ "$(id -u)" != "0" ]; then
-    echo "script must be run as root"
-    exit 1
-fi
-
-# load the latest release utils
+# load the generic utils utils
 # shellcheck source=/dev/null
-source "$SCRIPT_DIR/utils.sh"
+source "$(dirname "$SCRIPT_DIR")/utils.sh"
 
 EDGEX_STABLE_CHANNEL="2.1/stable"
-if [ -z "$DEFAULT_TEST_CHANNEL" ]; then
-    DEFAULT_TEST_CHANNEL="latest/beta"
-fi
-
 
 # helper function to download the snap, ack the assertion and return the
 # name of the file
@@ -103,8 +94,8 @@ if [[ -n $LOCAL_SNAP ]]; then
         exit 1
     fi
 else 
-    echo "testing snap from channel: $DEFAULT_TEST_CHANNEL"
-    export DEFAULT_TEST_CHANNEL
+    # default channel is handled in test suite's util script
+    echo "testing snap from default test channel"
 fi
 
 # make sure to remove the snap if it's installed before running

--- a/data/latest/run-all-tests-locally.sh
+++ b/data/latest/run-all-tests-locally.sh
@@ -93,26 +93,19 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 if [[ -n $LOCAL_SNAP ]]; then
     if [ -f "$LOCAL_SNAP" ]; then
         echo "testing local snap: $LOCAL_SNAP"
-        REVISION_TO_TEST=$LOCAL_SNAP
-        REVISION_TO_TEST_CHANNEL=""
+        export REVISION_TO_TEST=$LOCAL_SNAP
+        export REVISION_TO_TEST_CHANNEL=""
         # for now always need to test edgexfoundry locally with devmode
         # because we can't auto-connect interfaces that are needed
-        REVISION_TO_TEST_CONFINEMENT="--devmode"
+        export REVISION_TO_TEST_CONFINEMENT="--devmode"
     else
         echo "local snap to test: \"$LOCAL_SNAP\" does not exist"
         exit 1
     fi
 else 
     echo "testing snap from channel: $DEFAULT_TEST_CHANNEL"
-    REVISION_TO_TEST=""
-    REVISION_TO_TEST_CHANNEL=""
-    REVISION_TO_TEST_CONFINEMENT=""
+    export DEFAULT_TEST_CHANNEL
 fi
-
-# export the revision to test env vars
-export REVISION_TO_TEST
-export REVISION_TO_TEST_CHANNEL
-export REVISION_TO_TEST_CONFINEMENT
 
 # make sure to remove the snap if it's installed before running
 snap_remove 2>/dev/null > /dev/null

--- a/data/latest/test-config-hook.sh
+++ b/data/latest/test-config-hook.sh
@@ -64,8 +64,6 @@ conf_to_env[messagequeue_publish-topic-prefix]="MESSAGEQUEUE_PUBLISHTOPICPREFIX/
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/utils.sh"
 
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
-
 snap_remove
 
 # install the snap to make sure it installs

--- a/data/latest/test-device-virtual.sh
+++ b/data/latest/test-device-virtual.sh
@@ -9,7 +9,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 
 snap_remove
 

--- a/data/latest/test-install-config-paths.sh
+++ b/data/latest/test-install-config-paths.sh
@@ -9,7 +9,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 
 snap_remove
 

--- a/data/latest/test-install.sh
+++ b/data/latest/test-install.sh
@@ -10,8 +10,6 @@ source "$SCRIPT_DIR/utils.sh"
 
 snap_remove
 
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
-
 # install the snap to make sure it installs
 if [ -n "$REVISION_TO_TEST" ]; then
     snap_install "$REVISION_TO_TEST" "$REVISION_TO_TEST_CHANNEL" "$REVISION_TO_TEST_CONFINEMENT"

--- a/data/latest/test-network-interfaces.sh
+++ b/data/latest/test-network-interfaces.sh
@@ -11,7 +11,6 @@ source "$SCRIPT_DIR/utils.sh"
 snap_remove
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 
 # install the snap to make sure it installs
 if [ -n "$REVISION_TO_TEST" ]; then

--- a/data/latest/test-refresh-config-paths.sh
+++ b/data/latest/test-refresh-config-paths.sh
@@ -45,7 +45,7 @@ UPGRADED_VERSION=$(list_snap edgexfoundry)
 # wait for services to come online
 snap_wait_all_services_online
 
-echo "Successfully upgraded from $ORIGINAL_VERSION to $UPGRADED_VERSION"
+echo -e "Successfully upgraded:\n\tfrom: $ORIGINAL_VERSION\n\tto:   $UPGRADED_VERSION"
 
 echo "Checking for files with previous snap revision $SNAP_REVISION"
 

--- a/data/latest/test-refresh-config-paths.sh
+++ b/data/latest/test-refresh-config-paths.sh
@@ -25,7 +25,7 @@ else
     snap_install edgexfoundry $EDGEX_PREV_STABLE_CHANNEL
 fi
 
-ORIGINAL_VERSION=$(print_snap_version edgexfoundry)
+ORIGINAL_VERSION=$(list_snap edgexfoundry)
 echo "Installed $ORIGINAL_VERSION"
 
 SNAP_REVISION=$(snap run --shell edgexfoundry.consul -c "echo \$SNAP_REVISION")
@@ -40,7 +40,7 @@ if [ -n "$REVISION_TO_TEST" ]; then
 else
     snap_refresh edgexfoundry "$DEFAULT_TEST_CHANNEL"
 fi
-UPGRADED_VERSION=$(print_snap_version edgexfoundry)
+UPGRADED_VERSION=$(list_snap edgexfoundry)
 
 # wait for services to come online
 snap_wait_all_services_online

--- a/data/latest/test-refresh-config-paths.sh
+++ b/data/latest/test-refresh-config-paths.sh
@@ -12,7 +12,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 EDGEX_PREV_STABLE_CHANNEL="2.0/stable"
 
 snap_remove

--- a/data/latest/test-refresh-core-18-20.sh
+++ b/data/latest/test-refresh-core-18-20.sh
@@ -13,8 +13,6 @@ source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
 
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
-
 # remove the current snap
 snap_remove
 

--- a/data/latest/test-refresh-services.sh
+++ b/data/latest/test-refresh-services.sh
@@ -11,7 +11,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 EDGEX_STABLE_CHANNEL="2.0/stable"
 
 snap_remove

--- a/data/latest/test-refresh-services.sh
+++ b/data/latest/test-refresh-services.sh
@@ -39,7 +39,7 @@ UPGRADED_VERSION=$(list_snap edgexfoundry)
 # wait for services to come online
 snap_wait_all_services_online
 
-echo "Successfully upgraded from $ORIGINAL_VERSION to $UPGRADED_VERSION"
+echo -e "Successfully upgraded:\n\tfrom: $ORIGINAL_VERSION\n\tto:   $UPGRADED_VERSION"
 
 echo "All done. Cleaning up"
 # remove the snap to run the next test

--- a/data/latest/test-refresh-services.sh
+++ b/data/latest/test-refresh-services.sh
@@ -23,7 +23,7 @@ else
     echo "Installing snap from channel"
     snap_install edgexfoundry $EDGEX_STABLE_CHANNEL
 fi 
-ORIGINAL_VERSION=$(print_snap_version edgexfoundry)
+ORIGINAL_VERSION=$(list_snap edgexfoundry)
 echo "Installed $ORIGINAL_VERSION"
 
 # wait for services to come online
@@ -35,7 +35,7 @@ if [ -n "$REVISION_TO_TEST" ]; then
 else
     snap_refresh edgexfoundry "$DEFAULT_TEST_CHANNEL"
 fi
-UPGRADED_VERSION=$(print_snap_version edgexfoundry)
+UPGRADED_VERSION=$(list_snap edgexfoundry)
 
 # wait for services to come online
 snap_wait_all_services_online

--- a/data/latest/test-rules-engine.sh
+++ b/data/latest/test-rules-engine.sh
@@ -18,7 +18,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 
 snap_remove
 

--- a/data/latest/test-security-services-proxy-certs.sh
+++ b/data/latest/test-security-services-proxy-certs.sh
@@ -14,7 +14,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 
 # FIXME: The Ireland release no longer initializes an EdgeX CA used to
 # sign the TLS certificates for Kong or Vault. As of Ireland, TLS is no

--- a/data/latest/test-self-refresh-services.sh
+++ b/data/latest/test-self-refresh-services.sh
@@ -11,7 +11,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 
 snap_remove
 

--- a/data/latest/test-services-alive.sh
+++ b/data/latest/test-services-alive.sh
@@ -9,7 +9,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 
 snap_remove
 

--- a/data/latest/test-sys-mgmt-agent.sh
+++ b/data/latest/test-sys-mgmt-agent.sh
@@ -9,7 +9,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-beta}
 
 snap_remove
 

--- a/data/latest/utils.sh
+++ b/data/latest/utils.sh
@@ -9,6 +9,10 @@ fi
 # snippet from https://stackoverflow.com/a/246128/10102404
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+# default is either passed by the called or set here for the whole suite
+export DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-latest/beta}
+echo "DEFAULT_TEST_CHANNEL=$DEFAULT_TEST_CHANNEL"
+
 # load the generic utils
 # shellcheck source=/dev/null
 source "$(dirname "$SCRIPT_DIR")/utils.sh"

--- a/data/latest/utils.sh
+++ b/data/latest/utils.sh
@@ -1,21 +1,21 @@
 #!/bin/bash -e
 
-if [ "$(id -u)" != "0" ]; then
-    echo "script must be run as root"
-    exit 1
-fi
-
 # get the directory of this script
 # snippet from https://stackoverflow.com/a/246128/10102404
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-# default is either passed by the called or set here for the whole suite
-export DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-latest/beta}
-echo "DEFAULT_TEST_CHANNEL=$DEFAULT_TEST_CHANNEL"
-
 # load the generic utils
 # shellcheck source=/dev/null
 source "$(dirname "$SCRIPT_DIR")/utils.sh"
+
+# if default is not given, we use beta risk level of this track
+TRACK_BETA=latest/beta
+if [ -n "$DEFAULT_TEST_CHANNEL" ]; then
+    echo "DEFAULT_TEST_CHANNEL set to $DEFAULT_TEST_CHANNEL"
+else
+    echo "DEFAULT_TEST_CHANNEL not set. Setting to $TRACK_BETA"
+    export DEFAULT_TEST_CHANNEL=$TRACK_BETA
+fi
 
 snap_check_svcs()
 {

--- a/data/utils.sh
+++ b/data/utils.sh
@@ -158,7 +158,7 @@ snap_wait_port_status()
     fi
 }
 
-print_snap_version()
+list_snap()
 {
     local snap_name=$1
     snap list $snap_name | sed -n 2p

--- a/data/utils.sh
+++ b/data/utils.sh
@@ -10,6 +10,7 @@ snap_install()
     local the_snap=$1
     local the_channel=$2
     local confinement=$3
+    echo "Installing $the_snap with channel $the_channel"
 
     if [ "$the_snap" = "edgexfoundry" ]; then
         if [ -n "$confinement" ]; then
@@ -31,6 +32,7 @@ snap_refresh()
     local the_snap=$1
     local the_channel=$2
     local confinement=$3
+    echo "Refreshing $the_snap with channel $the_channel"
 
     if [ "$the_snap" = "edgexfoundry" ]; then
         if [ -n "$confinement" ]; then


### PR DESCRIPTION
This PR fixes the default channel passing for local and snap testing:
- export the default channel when running tests locally, so that child tests get the value and don't always default to "beta"
- set a global default channel which defaults to "latest/beta" instead of just "beta"