### PR TITLE
Add missing config-hook and device-virtual tests checkbox units

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ sudo DEFAULT_TEST_CHANNEL="<channel>" ./run-all-tests-locally.sh
 - Test that the system management agent works with the snap
 - Test that services are not listening on external network interfaces
 - Test that the rules engine works with the snap
+- Test that snap configure hook settings are supported by the edgexfoundry snap
+- Test that device-virtual creates devices and produces readings
 - Mandatory tests: see [units/test-plan.pxu#L113](./units/test-plan.pxu#L113)
 
 ## Limitations

--- a/units/jakarta.pxu
+++ b/units/jakarta.pxu
@@ -77,3 +77,20 @@ user: root
 environ: DEFAULT_TEST_CHANNEL REVISION_TO_TEST REVISION_TO_TEST_CHANNEL REVISION_TO_TEST_CONFINEMENT
 category_id: edgex
 flags: simple
+
+id: edgex/jakarta/config-hook
+_summary: Test that snap configure hook settings are supported by the edgexfoundry snap
+command: $PLAINBOX_PROVIDER_DATA/jakarta/test-config-hook.sh
+user: root
+environ: DEFAULT_TEST_CHANNEL REVISION_TO_TEST REVISION_TO_TEST_CHANNEL REVISION_TO_TEST_CONFINEMENT
+category_id: edgex
+flags: simple
+
+id: edgex/jakarta/device-virtual
+_summary: Test that device-virtual creates devices and produces readings
+command: $PLAINBOX_PROVIDER_DATA/jakarta/test-device-virtual.sh
+user: root
+environ: DEFAULT_TEST_CHANNEL REVISION_TO_TEST REVISION_TO_TEST_CHANNEL REVISION_TO_TEST_CONFINEMENT
+category_id: edgex
+flags: simple
+

--- a/units/latest.pxu
+++ b/units/latest.pxu
@@ -85,3 +85,20 @@ user: root
 environ: DEFAULT_TEST_CHANNEL REVISION_TO_TEST REVISION_TO_TEST_CHANNEL REVISION_TO_TEST_CONFINEMENT
 category_id: edgex
 flags: simple
+
+id: edgex/latest/config-hook
+_summary: Test that snap configure hook settings are supported by the edgexfoundry snap
+command: $PLAINBOX_PROVIDER_DATA/latest/test-config-hook.sh
+user: root
+environ: DEFAULT_TEST_CHANNEL REVISION_TO_TEST REVISION_TO_TEST_CHANNEL REVISION_TO_TEST_CONFINEMENT
+category_id: edgex
+flags: simple
+
+id: edgex/latest/device-virtual
+_summary: Test that device-virtual creates devices and produces readings
+command: $PLAINBOX_PROVIDER_DATA/latest/test-device-virtual.sh
+user: root
+environ: DEFAULT_TEST_CHANNEL REVISION_TO_TEST REVISION_TO_TEST_CHANNEL REVISION_TO_TEST_CONFINEMENT
+category_id: edgex
+flags: simple
+


### PR DESCRIPTION
Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>