### PR TITLE
remove `SHARED="true"` workaround as ekuiper 1.4.3 fixes it

### DIFF
--- a/data/latest/test-rules-engine.sh
+++ b/data/latest/test-rules-engine.sh
@@ -77,10 +77,7 @@ if [ -n "$(snap services edgexfoundry.app-service-configurable | grep edgexfound
 fi
 
 # create a stream
-# setting SHARED="true" in rules is currently necessary to avoid a number of issues in Kuiper 
-# that look like race conditions (e.g. incomplete JSON payload, slice bounds out of range).
-# We are investigating further and would create an issue once we have more information.
-if [ -z "$(edgexfoundry.kuiper-cli create stream stream1 '()WITH(FORMAT="JSON",TYPE="edgex",SHARED="true")' | grep '\bStream stream1 is created\b')" ] ; then
+if [ -z "$(edgexfoundry.kuiper-cli create stream stream1 '()WITH(FORMAT="JSON",TYPE="edgex")' | grep '\bStream stream1 is created\b')" ] ; then
     echo "cannot create kuiper stream"
     print_error_logs
     snap_remove


### PR DESCRIPTION
Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

Test passed with edgexfoundry snap (kuiper version 1.4.3):
```
sudo ./run-all-tests-locally.sh -t test-rules-engine.sh -s edgexfoundry_2.0.1-dev.71_amd64.snap -v
testing local snap: edgexfoundry_2.0.1-dev.71_amd64.snap
running single test: test-rules-engine.sh ...	PASSED
DEFAULT_TEST_CHANNEL not set. Setting to latest/beta
snap "edgexfoundry" is not installed
Installing edgexfoundry_2.0.1-dev.71_amd64.snap with channel 
edgexfoundry 2.0.1-dev.71 installed
waiting for all services to come online. Current retry count: 1/300
waiting for all services to come online. Current retry count: 2/300
waiting for all services to come online. Current retry count: 3/300
waiting for all services to come online. Current retry count: 4/300
all services up
waiting for device-virtual produce readings, current retry count: 1/60
waiting for device-virtual produce readings, current retry count: 2/60
waiting for device-virtual produce readings, current retry count: 3/60
waiting for device-virtual produce readings, current retry count: 4/60
waiting for device-virtual produce readings, current retry count: 5/60
waiting for device-virtual produce readings, current retry count: 6/60
waiting for device-virtual produce readings, current retry count: 7/60
waiting for device-virtual produce readings, current retry count: 8/60
waiting for device-virtual produce readings, current retry count: 9/60
waiting for device-virtual produce readings, current retry count: 10/60
waiting for device-virtual produce readings, current retry count: 11/60
waiting for device-virtual produce readings, current retry count: 12/60
waiting for device-virtual produce readings, current retry count: 13/60
device-virtual is producing readings now
check port 59720 status open services timed out, current retry count: 1/300
time="2022-03-11 11:08:32" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
create kuiper stream successfully
time="2022-03-11 11:08:32" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
create rule_log sucessfully
time="2022-03-11 11:08:32" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
create rule_mqtt) sucessfully
time="2022-03-11 11:08:32" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
create rule_edgex_message_bus) sucessfully
time="2022-03-11 11:08:32" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
run rule_log sucessfully
time="2022-03-11 11:08:32" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
run rule_mqtt sucessfully
time="2022-03-11 11:08:32" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
waiting for readings come into stream, current retry count: 1/60
time="2022-03-11 11:08:33" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
readings come into stream now
time="2022-03-11 11:08:33" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
time="2022-03-11 11:08:33" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
run rule_edgex_message_bus sucessfully
time="2022-03-11 11:08:33" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
time="2022-03-11 11:08:33" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
stop rule_log sucessfully
stop rule_mqtt sucessfully
time="2022-03-11 11:08:33" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
time="2022-03-11 11:08:33" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
drop rule_log sucessfully
drop rule_mqtt sucessfully
time="2022-03-11 11:08:33" level=info msg="Specified Kuiper base folder at location /var/snap/edgexfoundry/x1/kuiper.\n" file="conf/path.go:100"
drop stream sucessfully
edgexfoundry removed
```