### PR TITLE
Relative path to test files for local runs

### DIFF
--- a/data/jakarta/run-all-tests-locally.sh
+++ b/data/jakarta/run-all-tests-locally.sh
@@ -114,11 +114,6 @@ if [ -n "$SINGLE_TEST" ]; then
         snap_download_stable_and_default
     fi
 
-    if [ "$SINGLE_TEST" == "test-config-hook.sh" ]; then
-        TESTFILE="./test-files"
-        export TESTFILE
-    fi
-
     if stdout="$("$SCRIPT_DIR/$SINGLE_TEST" 2>&1)"; then
         printf -- "\tPASSED\n"
         if [ -n "$VERBOSE" ]; then

--- a/data/jakarta/test-config-hook.sh
+++ b/data/jakarta/test-config-hook.sh
@@ -148,7 +148,12 @@ validate_service_env()
 {
     service="$1"
     snapFile=$(cat "/var/snap/edgexfoundry/current/config/$service/res/$service.env" | sort)
-    testFile=$(cat "${TESTFILE:-"$SNAP/providers/checkbox-provider-edgex/data/jakarta/test-files"}/$service.env" | sort)
+    if [ -n "$SNAP" ]; then
+        testFilePath="$SNAP/providers/checkbox-provider-edgex/data/latest/test-files/$service.env"
+    else
+        testFilePath="./test-files/$service.env"
+    fi
+    testFile=$(cat $testFilePath)
 
     if [ "$snapFile" != "$testFile" ]; then
 	snap_remove

--- a/data/jakarta/test-config-hook.sh
+++ b/data/jakarta/test-config-hook.sh
@@ -147,18 +147,20 @@ test_options()
 validate_service_env()
 {
     service="$1"
-    snapFile=$(cat "/var/snap/edgexfoundry/current/config/$service/res/$service.env" | sort)
+    snapFilePath="/var/snap/edgexfoundry/current/config/$service/res/$service.env"
+    snapFile=$(cat "$snapFilePath" | sort)
     if [ -n "$SNAP" ]; then
         testFilePath="$SNAP/providers/checkbox-provider-edgex/data/latest/test-files/$service.env"
     else
         testFilePath="./test-files/$service.env"
     fi
-    testFile=$(cat $testFilePath)
+    testFile=$(cat "$testFilePath" | sort)
 
     if [ "$snapFile" != "$testFile" ]; then
-	snap_remove
-	echo "$service.env file doesn't match test file."
-	exit 1
+        snap_remove
+        echo "$service.env file doesn't match test file."
+        diff "$snapFilePath" "$testFilePath"
+        exit 1
     fi
 }
 

--- a/data/latest/run-all-tests-locally.sh
+++ b/data/latest/run-all-tests-locally.sh
@@ -114,11 +114,6 @@ if [ -n "$SINGLE_TEST" ]; then
         snap_download_stable_and_default
     fi
 
-    if [ "$SINGLE_TEST" == "test-config-hook.sh" ]; then
-        TESTFILE="./test-files"
-        export TESTFILE
-    fi
-
     if stdout="$("$SCRIPT_DIR/$SINGLE_TEST" 2>&1)"; then
         printf -- "\tPASSED\n"
         if [ -n "$VERBOSE" ]; then

--- a/data/latest/test-config-hook.sh
+++ b/data/latest/test-config-hook.sh
@@ -148,7 +148,12 @@ validate_service_env()
 {
     service="$1"
     snapFile=$(cat "/var/snap/edgexfoundry/current/config/$service/res/$service.env" | sort)
-    testFile=$(cat "${TESTFILE:-"$SNAP/providers/checkbox-provider-edgex/data/latest/test-files"}/$service.env" | sort)
+    if [ -n "$SNAP" ]; then
+        testFilePath="$SNAP/providers/checkbox-provider-edgex/data/latest/test-files/$service.env"
+    else
+        testFilePath="./test-files/$service.env"
+    fi
+    testFile=$(cat $testFilePath)
 
     if [ "$snapFile" != "$testFile" ]; then
 	snap_remove

--- a/data/latest/test-config-hook.sh
+++ b/data/latest/test-config-hook.sh
@@ -147,18 +147,20 @@ test_options()
 validate_service_env()
 {
     service="$1"
-    snapFile=$(cat "/var/snap/edgexfoundry/current/config/$service/res/$service.env" | sort)
+    snapFilePath="/var/snap/edgexfoundry/current/config/$service/res/$service.env"
+    snapFile=$(cat "$snapFilePath" | sort)
     if [ -n "$SNAP" ]; then
         testFilePath="$SNAP/providers/checkbox-provider-edgex/data/latest/test-files/$service.env"
     else
         testFilePath="./test-files/$service.env"
     fi
-    testFile=$(cat $testFilePath)
+    testFile=$(cat "$testFilePath" | sort)
 
     if [ "$snapFile" != "$testFile" ]; then
-	snap_remove
-	echo "$service.env file doesn't match test file."
-	exit 1
+        snap_remove
+        echo "$service.env file doesn't match test file."
+        diff "$snapFilePath" "$testFilePath"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
This PR tries to fix the same issue as #36. The previous fix only worked when running the config hook test as a single test, not when running all tests.

