### PR TITLE
Replace `2.0/stable` with `2.1/stable` as base snap for refresh tests

### DIFF
--- a/data/jakarta/run-all-tests-locally.sh
+++ b/data/jakarta/run-all-tests-locally.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # load the generic utils utils
 # shellcheck source=/dev/null
 source "$(dirname "$SCRIPT_DIR")/utils.sh"
-EDGEX_STABLE_CHANNEL="2.0/stable"
+EDGEX_STABLE_CHANNEL="2.1/edge"
 
 # helper function to download the snap, ack the assertion and return the
 # name of the file
@@ -109,7 +109,7 @@ if [ -n "$SINGLE_TEST" ]; then
     fi
 
     if [ "$SINGLE_TEST" == "test-refresh-config-paths.sh" ]; then
-        EDGEX_PREV_STABLE_SNAP_FILE=$(snap_download_and_ack edgexfoundry --channel=2.0/stable)
+        EDGEX_PREV_STABLE_SNAP_FILE=$(snap_download_and_ack edgexfoundry --channel=2.1/edge)
         export EDGEX_PREV_STABLE_SNAP_FILE
         snap_download_stable_and_default
     fi

--- a/data/jakarta/run-all-tests-locally.sh
+++ b/data/jakarta/run-all-tests-locally.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # load the generic utils utils
 # shellcheck source=/dev/null
 source "$(dirname "$SCRIPT_DIR")/utils.sh"
-EDGEX_STABLE_CHANNEL="2.1/edge"
+EDGEX_STABLE_CHANNEL="2.1/stable"
 
 # helper function to download the snap, ack the assertion and return the
 # name of the file
@@ -109,7 +109,7 @@ if [ -n "$SINGLE_TEST" ]; then
     fi
 
     if [ "$SINGLE_TEST" == "test-refresh-config-paths.sh" ]; then
-        EDGEX_PREV_STABLE_SNAP_FILE=$(snap_download_and_ack edgexfoundry --channel=2.1/edge)
+        EDGEX_PREV_STABLE_SNAP_FILE=$(snap_download_and_ack edgexfoundry --channel=2.1/stable)
         export EDGEX_PREV_STABLE_SNAP_FILE
         snap_download_stable_and_default
     fi

--- a/data/jakarta/test-refresh-config-paths.sh
+++ b/data/jakarta/test-refresh-config-paths.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # This test checks if all files in $SNAP_DATA don't reference the previous revision
-# after upgrading the snap from 2.1/edge to 2.1/beta
+# after upgrading the snap from 2.1/stable to 2.1/beta
 
 # get the directory of this script
 # snippet from https://stackoverflow.com/a/246128/10102404
@@ -12,7 +12,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-EDGEX_PREV_STABLE_CHANNEL="2.1/edge"
+EDGEX_PREV_STABLE_CHANNEL="2.1/stable"
 
 snap_remove
 
@@ -33,7 +33,7 @@ echo "Getting the revision number for this channel: $SNAP_REVISION"
 # wait for services to come online
 snap_wait_all_services_online
 
-# now upgrade the snap from 2.1/edge to 2.1/stable
+# now upgrade the snap from 2.1/stable to 2.1/beta
 if [ -n "$REVISION_TO_TEST" ]; then
     snap_install "$REVISION_TO_TEST" "$REVISION_TO_TEST_CHANNEL" "$REVISION_TO_TEST_CONFINEMENT"
 else

--- a/data/jakarta/test-refresh-config-paths.sh
+++ b/data/jakarta/test-refresh-config-paths.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # This test checks if all files in $SNAP_DATA don't reference the previous revision
-# after upgrading the snap from 2.0/stable to 2.1/beta
+# after upgrading the snap from 2.1/edge to 2.1/beta
 
 # get the directory of this script
 # snippet from https://stackoverflow.com/a/246128/10102404
@@ -12,7 +12,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-EDGEX_PREV_STABLE_CHANNEL="2.0/stable"
+EDGEX_PREV_STABLE_CHANNEL="2.1/edge"
 
 snap_remove
 
@@ -33,7 +33,7 @@ echo "Getting the revision number for this channel: $SNAP_REVISION"
 # wait for services to come online
 snap_wait_all_services_online
 
-# now upgrade the snap from 2.0/stable to 2.1/stable
+# now upgrade the snap from 2.1/edge to 2.1/stable
 if [ -n "$REVISION_TO_TEST" ]; then
     snap_install "$REVISION_TO_TEST" "$REVISION_TO_TEST_CHANNEL" "$REVISION_TO_TEST_CONFINEMENT"
 else

--- a/data/jakarta/test-refresh-services.sh
+++ b/data/jakarta/test-refresh-services.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# This test validates a smooth upgrade between 2.0/stable channel and 2.1/beta channel
+# This test validates a smooth upgrade between 2.1/edge channel and 2.1/beta channel
 
 # get the directory of this script
 # snippet from https://stackoverflow.com/a/246128/10102404
@@ -11,7 +11,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-EDGEX_STABLE_CHANNEL="2.0/stable"
+EDGEX_STABLE_CHANNEL="2.1/edge"
 
 snap_remove
 
@@ -28,7 +28,7 @@ echo "Installed $ORIGINAL_VERSION"
 # wait for services to come online
 snap_wait_all_services_online
 
-# now upgrade the snap from 2.0/stable to 2.1/beta
+# now upgrade the snap from 2.1/edge to 2.1/beta
 if [ -n "$REVISION_TO_TEST" ]; then
     snap_install "$REVISION_TO_TEST" "$REVISION_TO_TEST_CHANNEL" "$REVISION_TO_TEST_CONFINEMENT"
 else

--- a/data/jakarta/test-refresh-services.sh
+++ b/data/jakarta/test-refresh-services.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# This test validates a smooth upgrade between 2.1/edge channel and 2.1/beta channel
+# This test validates a smooth upgrade between 2.1/stable channel and 2.1/beta channel
 
 # get the directory of this script
 # snippet from https://stackoverflow.com/a/246128/10102404
@@ -11,7 +11,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-EDGEX_STABLE_CHANNEL="2.1/edge"
+EDGEX_STABLE_CHANNEL="2.1/stable"
 
 snap_remove
 
@@ -28,7 +28,7 @@ echo "Installed $ORIGINAL_VERSION"
 # wait for services to come online
 snap_wait_all_services_online
 
-# now upgrade the snap from 2.1/edge to 2.1/beta
+# now upgrade the snap from 2.1/stable to 2.1/beta
 if [ -n "$REVISION_TO_TEST" ]; then
     snap_install "$REVISION_TO_TEST" "$REVISION_TO_TEST_CHANNEL" "$REVISION_TO_TEST_CONFINEMENT"
 else


### PR DESCRIPTION
2.1 channel is not exiting anymore, so checkbox tests that used 2.0/stable as a base snap for refresh/upgrade tests, need to replace it with 2.1/edge.