### PR TITLE
Replace `2.1/stable` with `latest/stable` as base snap for refresh tests

### DIFF
--- a/data/latest/run-all-tests-locally.sh
+++ b/data/latest/run-all-tests-locally.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$(dirname "$SCRIPT_DIR")/utils.sh"
 
 EDGEX_STABLE_CHANNEL="latest/stable"
-EDGEX_PREV_STABLE_CHANNEL="2.1/stable"
+EDGEX_PREV_STABLE_CHANNEL="latest/stable"
 
 # helper function to download the snap, ack the assertion and return the
 # name of the file

--- a/data/latest/test-refresh-config-paths.sh
+++ b/data/latest/test-refresh-config-paths.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-EDGEX_PREV_STABLE_CHANNEL="2.1/stable"
+EDGEX_PREV_STABLE_CHANNEL="latest/stable"
 
 snap_remove
 

--- a/data/latest/test-refresh-core-18-20.sh
+++ b/data/latest/test-refresh-core-18-20.sh
@@ -17,7 +17,7 @@ START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
 snap_remove
 
 # install previous stable
-EDGEX_PREV_STABLE_CHANNEL="2.1/stable"
+EDGEX_PREV_STABLE_CHANNEL="latest/stable"
 snap_install edgexfoundry $EDGEX_PREV_STABLE_CHANNEL
 
 # wait for services to come online

--- a/data/latest/test-refresh-services.sh
+++ b/data/latest/test-refresh-services.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "$SCRIPT_DIR/utils.sh"
 
 START_TIME=$(date +"%Y-%m-%d %H:%M:%S")
-EDGEX_PREV_STABLE_CHANNEL="2.1/stable"
+EDGEX_PREV_STABLE_CHANNEL="latest/stable"
 
 snap_remove
 


### PR DESCRIPTION
to avoid rely on independent tracks