### PR TITLE
Set environment in test script

### DIFF
--- a/data/latest/run-go-tests.sh
+++ b/data/latest/run-go-tests.sh
@@ -10,6 +10,13 @@ SUITE=$1 # name of the Go testing package
 export PLATFORM_CHANNEL=$DEFAULT_TEST_CHANNEL
 export SERVICE_CHANNEL=$DEFAULT_TEST_CHANNEL
 
+# Setup the environment
+export GIT_EXEC_PATH=$SNAP/usr/lib/git-core
+export GIT_TEMPLATE_DIR=$SNAP/usr/share/git-core/templates
+export GIT_CONFIG_NOSYSTEM=1
+export PATH=$PATH:$SNAP/usr/lib/go-1.18/bin
+export CGO_ENABLED=0
+
 rm -rf tmp
 
 git clone --config advice.detachedHead=false --depth 1 --branch v3 \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,10 +22,6 @@ plugs:
     target: $SNAP/providers/checkbox-provider-base
     default-provider: checkbox20
 
-layout:
-    /usr/share/git-core:
-      bind: $SNAP_COMMON/usr/share/git-core
-
 apps:
   checkbox-cli:
     command-chain: [bin/wrapper_local]
@@ -57,10 +53,6 @@ apps:
     command-chain: [bin/wrapper_local]
     command: bin/latest
     plugs: *standard
-    environment:
-      GIT_EXEC_PATH: $SNAP/usr/lib/git-core
-      GIT_TEMPLATE_DIR: $SNAP/usr/share/git-core/templates
-      GIT_CONFIG_NOSYSTEM: 1
   test-runner:
     command-chain: [bin/wrapper_local]
     command: bin/test-runner
@@ -102,9 +94,9 @@ parts:
   testing-tools:
       plugin: nil
       stage-packages:
-        - git
-        - golang-1.18-go
-        - libcurl4-openssl-dev
+        - git # path and config set in run-go-tests.sh
+        - golang-1.18-go # PATH set in run-go-tests.sh
+        # - libcurl4-openssl-dev
         # - curl # this uses libcurl3. adding it causes libssl errors in openssl commands
         # - openssl
         # - libssl-dev


### PR DESCRIPTION
The environment variables passed to the `latest` app defined in snapcraft.yaml don't reach the intended run-go-test.sh script.

This PR moves the environment variable definitions to the run-go-test.sh script itself. It also sets the Go path, since it is missing. The `libcurl4-openssl-dev` package is removed as it should not be needed, assuming the root cause is the path to git executable rather than missing the package.