### PR TITLE
Run edgex-no-sec test for latest test suite

### DIFF
--- a/units/latest.pxu
+++ b/units/latest.pxu
@@ -13,7 +13,7 @@ flags: simple
 # flags: simple
 
 id: edgex/latest/edgex-no-sec
-_summary: Test edgexfoundry snap with disabled security together with few other EdgeX snaps
+_summary: Test edgexfoundry snap with disabled security
 command: $PLAINBOX_PROVIDER_DATA/latest/run-go-tests.sh edgex-no-sec
 user: root
 category_id: edgex

--- a/units/latest.pxu
+++ b/units/latest.pxu
@@ -12,9 +12,9 @@ flags: simple
 # category_id: edgex
 # flags: simple
 
-# id: edgex/latest/edgex-no-sec
-# _summary: Test edgexfoundry snap with disabled security together with few other EdgeX snaps
-# command: $PLAINBOX_PROVIDER_DATA/latest/run-go-tests.sh edgex-no-sec
-# user: root
-# category_id: edgex
-# flags: simple
+id: edgex/latest/edgex-no-sec
+_summary: Test edgexfoundry snap with disabled security together with few other EdgeX snaps
+command: $PLAINBOX_PROVIDER_DATA/latest/run-go-tests.sh edgex-no-sec
+user: root
+category_id: edgex
+flags: simple


### PR DESCRIPTION
This PR actives the edgex-no-sec test for latest test suite, as the existing Consul path issue in edgex-no-sec test will be solved by https://github.com/canonical/edgex-snap-testing/pull/149