### PR TITLE
Stage `snapd` package to add `snap` binary to the package

### DIFF
--- a/data/latest/run-go-tests.sh
+++ b/data/latest/run-go-tests.sh
@@ -35,6 +35,9 @@ print_logs() {
 }
 trap print_logs EXIT
 
+# Use the staged snap command available to the user
+sed -i 's/sudo snap/snap/g' ./test/utils/snap.go
+
 # TODO:
 sed -i '/TestTLSCert/a t.Skip("https://github.com/canonical/edgex-checkbox-provider/issues/52")' ./test/suites/edgexfoundry/proxy_test.go
 sed -i '/TestAddProxyUser/a t.Skip("https://github.com/canonical/edgex-checkbox-provider/issues/55")' ./test/suites/edgexfoundry/proxy_test.go

--- a/data/latest/run-go-tests.sh
+++ b/data/latest/run-go-tests.sh
@@ -35,8 +35,10 @@ print_logs() {
 }
 trap print_logs EXIT
 
-# Use the staged snap command available to the user
-sed -i 's/sudo snap/snap/g' ./test/utils/snap.go
+# The sudoer's path (secure_path) misses $SNAP/usr/bin/ which we need for
+# commands such as: snap, lsof. Remove all sudo commands and run everything as
+# current user:
+find test -type f -exec sed -i 's/sudo //g' {} +
 
 # TODO:
 sed -i '/TestTLSCert/a t.Skip("https://github.com/canonical/edgex-checkbox-provider/issues/52")' ./test/suites/edgexfoundry/proxy_test.go

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,12 +92,12 @@ parts:
     organize:
       '*': bin/
   testing-tools:
-      plugin: nil
-      stage-packages:
-        - git # path and config set in run-go-tests.sh
-        - golang-1.18-go # PATH set in run-go-tests.sh
-        # - libcurl4-openssl-dev
-        # - curl # this uses libcurl3. adding it causes libssl errors in openssl commands
-        # - openssl
-        # - libssl-dev
-      
+    plugin: nil
+    stage-packages:
+      - git # path and config set in run-go-tests.sh
+      - golang-1.18-go # PATH set in run-go-tests.sh
+      - snapd
+      # - libcurl4-openssl-dev
+      # - curl # this uses libcurl3. adding it causes libssl errors in openssl commands
+      # - openssl
+      # - libssl-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,12 +92,12 @@ parts:
     organize:
       '*': bin/
   testing-tools:
-    plugin: nil
-    stage-packages:
-      - git # path and config set in run-go-tests.sh
-      - golang-1.18-go # PATH set in run-go-tests.sh
-      - snapd
-      # - libcurl4-openssl-dev
-      # - curl # this uses libcurl3. adding it causes libssl errors in openssl commands
-      # - openssl
-      # - libssl-dev
+      plugin: nil
+      stage-packages:
+        - git # path and config set in run-go-tests.sh
+        - golang-1.18-go # PATH set in run-go-tests.sh
+        - snapd
+        # - libcurl4-openssl-dev
+        # - curl # this uses libcurl3. adding it causes libssl errors in openssl commands
+        # - openssl
+        # - libssl-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -95,8 +95,11 @@ parts:
       plugin: nil
       stage-packages:
         - git # path and config set in run-go-tests.sh
-        - golang-1.18-go # PATH set in run-go-tests.sh
-        - snapd
+        - golang-1.18-go # path set in run-go-tests.sh
+        # The checkbox-edgexfoundry snap based on core20 expects the snap binary 
+        # at a path that isn't compatible with how snapd is installed on UC16.
+        # See: https://github.com/canonical/edgex-checkbox-provider/issues/59
+        - snapd # re-install the snap command
         # - libcurl4-openssl-dev
         # - curl # this uses libcurl3. adding it causes libssl errors in openssl commands
         # - openssl


### PR DESCRIPTION
Fixes #59 

```
$ multipass launch core --name=uc16
Launched: uc16                                                 
$ multipass shell uc16

# transfer the snap from outside to multipass instance:
# multipass transfer checkbox-edgexfoundry_2.0_amd64.snap uc16:

$ ls
checkbox-edgexfoundry_2.0_amd64.snap
$ sudo snap install --devmode --dangerous ./checkbox-edgexfoundry_2.0_amd64.snap 
checkbox-edgexfoundry 2.0 installed

$ sudo snap connect checkbox-edgexfoundry:checkbox-runtime checkbox20:checkbox-runtime
$ sudo snap connect checkbox-edgexfoundry:provider-resource checkbox20:provider-resource
$ sudo snap connect checkbox-edgexfoundry:provider-checkbox checkbox20:provider-checkbox

$ snap run --shell checkbox-edgexfoundry.latest

ubuntu@uc16:/home/ubuntu$ snap version
snap    2.58+20.04
snapd   2.58
series  16
kernel  4.4.0-187-generic

ubuntu@uc16:/home/ubuntu$ which snap
/snap/checkbox-edgexfoundry/x1/usr/bin/snap

ubuntu@uc16:/home/ubuntu$ sudo snap
sudo: snap: command not found
```

As shown, `snap` works now but `sudo snap` still does not. That's because the snap command is available under `$SNAP/usr/bin/` which isn't in sudoer's path:
```
ubuntu@uc16:/home/ubuntu$ sudo cat /etc/sudoers | grep secure_path
Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
```
I tried a few workarounds with no success and ended up removing all sudo commands. This also fixes #61.


```
$ sudo DEFAULT_TEST_CHANNEL="latest/beta" checkbox-edgexfoundry.latest
...
-------------[ Running job 22 / 22. Estimated time left: unknown ]--------------
---------------------------[ Test edgexfoundry snap ]---------------------------
ID: com.canonical.certification::edgex/latest/edgexfoundry
Category: com.canonical.certification::edgex
... 8< -------------------------------------------------------------------------
Cloning into 'tmp/edgex-snap-testing'...
Running Go snap tests for edgexfoundry:
go: downloading github.com/stretchr/testify v1.8.1
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.1
2023/02/13 10:16:20 [CLEAN]
2023/02/13 10:16:20 [exec] snap remove --purge edgexfoundry
2023/02/13 10:16:21 [stdout] 2023-02-13T10:16:21Z INFO Waiting for "snap.edgexfoundry.kong-daemon.service" to stop.
2023/02/13 10:16:29 [stdout] edgexfoundry removed
2023/02/13 10:16:29 [SETUP]
2023/02/13 10:16:29 [exec] snap install edgexfoundry --channel=latest/beta
2023/02/13 10:17:28 [stdout] edgexfoundry (beta) 3.0.0-dev.29 from Canonical** installed
2023/02/13 10:17:28 Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis), 8000 (kong)
2023/02/13 10:17:29 Retry 2/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/02/13 10:17:30 Retry 3/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command)
2023/02/13 10:17:30 [exec] snap start --enable edgexfoundry.support-scheduler
2023/02/13 10:17:31 [stdout] Started.
2023/02/13 10:17:31 Retry 1/60: Waiting for ports: 59861 (support-scheduler)
=== RUN   TestChangeStartupMsg_app
    config_test.go:26: Set and verify new startup message: snap-testing (app)
    exec.go:19: [exec] snap set edgexfoundry apps.support-scheduler.config.service-startupmsg='snap-testing (app)'
    exec.go:19: [exec] snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] 2023-02-13T10:17:32Z INFO Waiting for "snap.edgexfoundry.support-scheduler.service" to stop.
    exec.go:101: [stdout] Restarted.
    net.go:140: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis), 8000 (kong)
    config_test.go:109: Retry 1/10: Waiting for startup message: snap-testing (app)
    exec.go:19: [exec] journalctl --since "2023-02-13 10:17:31" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config_test.go:114: Found startup message: snap-testing (app)
    config_test.go:34: Unset and check default message
    exec.go:19: [exec] snap unset edgexfoundry apps.support-scheduler.config.service-startupmsg
    exec.go:19: [exec] snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:140: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis), 8000 (kong)
    config_test.go:109: Retry 1/10: Waiting for startup message: This is the Support Scheduler Microservice
    exec.go:19: [exec] journalctl --since "2023-02-13 10:17:38" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config_test.go:114: Found startup message: This is the Support Scheduler Microservice
    exec.go:19: [exec] snap unset edgexfoundry apps.support-scheduler.config.service-startupmsg
    exec.go:19: [exec] snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
--- PASS: TestChangeStartupMsg_app (9.83s)
=== RUN   TestChangeStartupMsg_global
    config_test.go:53: Set and verify new startup message: snap-testing (global)
    exec.go:19: [exec] snap set edgexfoundry config.service-startupmsg='snap-testing (global)'
    exec.go:19: [exec] snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:140: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis), 8000 (kong)
    config_test.go:109: Retry 1/10: Waiting for startup message: snap-testing (global)
    exec.go:19: [exec] journalctl --since "2023-02-13 10:17:41" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config_test.go:114: Found startup message: snap-testing (global)
    config_test.go:61: Unset and check default message
    exec.go:19: [exec] snap unset edgexfoundry config.service-startupmsg
    exec.go:19: [exec] snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:140: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis), 8000 (kong)
    config_test.go:109: Retry 1/10: Waiting for startup message: This is the Support Scheduler Microservice
    exec.go:19: [exec] journalctl --since "2023-02-13 10:17:43" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config_test.go:114: Found startup message: This is the Support Scheduler Microservice
    exec.go:19: [exec] snap unset edgexfoundry config.service-startupmsg
    exec.go:19: [exec] snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
--- PASS: TestChangeStartupMsg_global (5.48s)
=== RUN   TestChangeStartupMsg_mixedGlobalApp
    config_test.go:83: Set local and global startup messages and verify that local has taken precedence
    exec.go:19: [exec] snap set edgexfoundry apps.support-scheduler.config.service-startupmsg='snap-testing (app specific)'
    exec.go:101: [stdout] 2023-02-13T10:17:46Z INFO task ignored
    exec.go:19: [exec] snap set edgexfoundry config.service-startupmsg='snap-testing (global override)'
    exec.go:19: [exec] snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:140: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis), 8000 (kong)
    config_test.go:109: Retry 1/10: Waiting for startup message: snap-testing (app specific)
    exec.go:19: [exec] journalctl --since "2023-02-13 10:17:47" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config_test.go:114: Found startup message: snap-testing (app specific)
    config_test.go:92: Unset and check default message
    exec.go:19: [exec] snap unset edgexfoundry apps.support-scheduler.config.service-startupmsg
    exec.go:19: [exec] snap unset edgexfoundry config.service-startupmsg
    exec.go:19: [exec] snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
    net.go:140: Retry 1/180: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis), 8000 (kong)
    config_test.go:109: Retry 1/10: Waiting for startup message: This is the Support Scheduler Microservice
    exec.go:19: [exec] journalctl --since "2023-02-13 10:17:49" --no-pager | grep "edgexfoundry.support-scheduler"|| true
    config_test.go:114: Found startup message: This is the Support Scheduler Microservice
    exec.go:19: [exec] snap unset edgexfoundry config.service-startupmsg
    exec.go:19: [exec] snap restart edgexfoundry.support-scheduler
    exec.go:101: [stdout] Restarted.
--- PASS: TestChangeStartupMsg_mixedGlobalApp (5.41s)
=== RUN   TestCommon
=== RUN   TestCommon/config
=== RUN   TestCommon/config/autostart
=== RUN   TestCommon/net
=== RUN   TestCommon/net/ports_open
    net.go:140: Retry 1/60: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis), 8000 (kong)
=== CONT  TestCommon/net
    net.go:140: Retry 1/60: Waiting for ports: 59880 (core-data), 59881 (core-metadata), 59882 (core-command), 8200 (vault), 8500 (consul), 5432 (kong-database), 6379 (redis)
=== RUN   TestCommon/net/ports_not_listening_on_all_interfaces
    exec.go:19: [exec] lsof -nPi :59880 || true
    net.go:260: Looking for '*:59880 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :59881 || true
    net.go:260: Looking for '*:59881 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :59882 || true
    net.go:260: Looking for '*:59882 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :8200 || true
    net.go:260: Looking for '*:8200 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :8500 || true
    net.go:260: Looking for '*:8500 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :5432 || true
    net.go:260: Looking for '*:5432 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :6379 || true
    net.go:260: Looking for '*:6379 (LISTEN)'
=== RUN   TestCommon/net/ports_listening_on_localhost
    exec.go:19: [exec] lsof -nPi :59880 || true
    net.go:260: Looking for '127.0.0.1:59880 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :59881 || true
    net.go:260: Looking for '127.0.0.1:59881 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :59882 || true
    net.go:260: Looking for '127.0.0.1:59882 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :8200 || true
    net.go:260: Looking for '127.0.0.1:8200 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :8500 || true
    net.go:260: Looking for '127.0.0.1:8500 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :5432 || true
    net.go:260: Looking for '127.0.0.1:5432 (LISTEN)'
    exec.go:19: [exec] lsof -nPi :6379 || true
    net.go:260: Looking for '127.0.0.1:6379 (LISTEN)'
=== RUN   TestCommon/packaging
=== RUN   TestCommon/packaging/semantic_snap_version
    exec.go:19: [exec] snap info edgexfoundry | grep installed | awk '{print $2}'
    exec.go:101: [stdout] 3.0.0-dev.29
--- PASS: TestCommon (0.65s)
    --- PASS: TestCommon/config (0.00s)
        --- PASS: TestCommon/config/autostart (0.00s)
    --- PASS: TestCommon/net (0.12s)
        --- PASS: TestCommon/net/ports_open (0.00s)
        --- PASS: TestCommon/net/ports_not_listening_on_all_interfaces (0.07s)
        --- PASS: TestCommon/net/ports_listening_on_localhost (0.05s)
    --- PASS: TestCommon/packaging (0.53s)
        --- PASS: TestCommon/packaging/semantic_snap_version (0.53s)
=== RUN   TestTLSCert
    proxy_test.go:20: https://github.com/canonical/edgex-checkbox-provider/issues/52
--- SKIP: TestTLSCert (0.00s)
=== RUN   TestAddProxyUser
    proxy_test.go:67: https://github.com/canonical/edgex-checkbox-provider/issues/55
--- SKIP: TestAddProxyUser (0.00s)
PASS
2023/02/13 10:17:52 [TEARDOWN]
2023/02/13 10:17:52 [exec] (journalctl --since "2023-02-13 10:16:29" --no-pager | grep "edgexfoundry"|| true) > edgexfoundry.log
Wrote snap logs to /home/ubuntu/tmp/edgex-snap-testing/test/suites/edgexfoundry/edgexfoundry.log
2023/02/13 10:17:52 [exec] snap remove --purge edgexfoundry
2023/02/13 10:17:54 [stdout] 2023-02-13T10:17:54Z INFO Waiting for "snap.edgexfoundry.core-metadata.service" to stop.
2023/02/13 10:17:55 [stdout] 2023-02-13T10:17:55Z INFO Waiting for "snap.edgexfoundry.support-notifications.service" to stop.
2023/02/13 10:17:57 [stdout] 2023-02-13T10:17:57Z INFO Waiting for "snap.edgexfoundry.core-data.service" to stop.
2023/02/13 10:18:04 [stdout] edgexfoundry removed
ok  	edgex-snap-testing/test/suites/edgexfoundry	103.869s
```