### PR TITLE
Use latest/beta as default channel

### DIFF
--- a/data/latest/run-go-tests.sh
+++ b/data/latest/run-go-tests.sh
@@ -6,6 +6,15 @@
 # Arguments:
 SUITE=$1 # name of the Go testing package
 
+# Default to beta risk level of this track
+TRACK_BETA=latest/beta
+if [ -n "$DEFAULT_TEST_CHANNEL" ]; then
+    echo "DEFAULT_TEST_CHANNEL set to $DEFAULT_TEST_CHANNEL"
+else
+    echo "DEFAULT_TEST_CHANNEL not set. Setting to $TRACK_BETA"
+    export DEFAULT_TEST_CHANNEL=$TRACK_BETA
+fi
+
 # Map input variables to those expected by the Go tests
 export PLATFORM_CHANNEL=$DEFAULT_TEST_CHANNEL
 export SERVICE_CHANNEL=$DEFAULT_TEST_CHANNEL

--- a/data/latest/run-go-tests.sh
+++ b/data/latest/run-go-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 # This scripts runs the EdgeX Snap tests maintained in
 # https://github.com/canonical/edgex-snap-testing
@@ -6,28 +6,21 @@
 # Arguments:
 SUITE=$1 # name of the Go testing package
 
-# Default to beta risk level of this track
-TRACK_BETA=latest/beta
-if [ -n "$DEFAULT_TEST_CHANNEL" ]; then
-    echo "DEFAULT_TEST_CHANNEL set to $DEFAULT_TEST_CHANNEL"
-else
-    echo "DEFAULT_TEST_CHANNEL not set. Setting to $TRACK_BETA"
-    export DEFAULT_TEST_CHANNEL=$TRACK_BETA
-fi
+DEFAULT_TEST_CHANNEL=${DEFAULT_TEST_CHANNEL:-latest/beta}
 
 # Map input variables to those expected by the Go tests
-export PLATFORM_CHANNEL=$DEFAULT_TEST_CHANNEL
-export SERVICE_CHANNEL=$DEFAULT_TEST_CHANNEL
+PLATFORM_CHANNEL=$DEFAULT_TEST_CHANNEL
+SERVICE_CHANNEL=$DEFAULT_TEST_CHANNEL
 
-# Setup the environment
-export GIT_EXEC_PATH=$SNAP/usr/lib/git-core
-export GIT_TEMPLATE_DIR=$SNAP/usr/share/git-core/templates
-export GIT_CONFIG_NOSYSTEM=1
-export PATH=$PATH:$SNAP/usr/lib/go-1.18/bin
-export CGO_ENABLED=0
+GIT_EXEC_PATH=$SNAP/usr/lib/git-core
+GIT_TEMPLATE_DIR=$SNAP/usr/share/git-core/templates
+GIT_CONFIG_NOSYSTEM=1
+PATH=$PATH:$SNAP/usr/lib/go-1.18/bin
+CGO_ENABLED=0
+
+export PLATFORM_CHANNEL SERVICE_CHANNEL GIT_EXEC_PATH GIT_TEMPLATE_DIR GIT_CONFIG_NOSYSTEM PATH CGO_ENABLED
 
 rm -rf tmp
-
 git clone --config advice.detachedHead=false --depth 1 --branch v3 \
     https://github.com/canonical/edgex-snap-testing.git tmp/edgex-snap-testing
 cd tmp/edgex-snap-testing
@@ -48,5 +41,7 @@ trap print_logs EXIT
 sed -i '/TestTLSCert/a t.Skip("https://github.com/canonical/edgex-checkbox-provider/issues/52")' ./test/suites/edgexfoundry/proxy_test.go
 sed -i '/TestAddProxyUser/a t.Skip("https://github.com/canonical/edgex-checkbox-provider/issues/55")' ./test/suites/edgexfoundry/proxy_test.go
 
-echo "Running Go snap tests for $SUITE:"
+echo -e "\nRun the '$SUITE' test suite:"
 go test -p 1 -timeout 30m -v ./test/suites/$SUITE
+
+echo -e "\n"


### PR DESCRIPTION
Testflinger doesn't set the environment variable when on new beta releases. We need to set it as default otherwise, latest/edge will be installed on releases of latest/beta.

As done [originally](https://github.com/canonical/edgex-checkbox-provider/blob/4771fdc52c4e486c5a938d7a1adf6603e88cdfb6/data/latest/utils.sh#L11-L18) and for other tracks.