### PR TITLE
Remove the option to skip the proxy test as it is no longer available

### DIFF
--- a/data/latest/run-go-tests.sh
+++ b/data/latest/run-go-tests.sh
@@ -42,10 +42,6 @@ trap print_logs EXIT
 # current user:
 find test -type f -exec sed -i 's/sudo //g' {} +
 
-# TODO:
-sed -i '/TestTLSCert/a t.Skip("https://github.com/canonical/edgex-checkbox-provider/issues/52")' ./test/suites/edgexfoundry/proxy_test.go
-sed -i '/TestAddProxyUser/a t.Skip("https://github.com/canonical/edgex-checkbox-provider/issues/55")' ./test/suites/edgexfoundry/proxy_test.go
-
 echo -e "\nRun the '$SUITE' test suite:"
 go test -p 1 -timeout 30m -v ./test/suites/$SUITE
 


### PR DESCRIPTION
Removing the replacement code since, the corresponding tests have been removed in https://github.com/canonical/edgex-snap-hooks/pull/85

This will resolve #52 and #55

